### PR TITLE
CB-9712 CLI 5.3 breaks with node 3.3.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+// Entry point is needed so that the module could be required.
+// The module dir path will be need to copy resources from it.
+exports = module.exports = {
+    dirname: __dirname
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://git-wip-us.apache.org/repos/asf/cordova-app-hello-world.git"
   },
+  "main": "index.js",
   "keywords": [
     "ecosystem:cordova"
   ],


### PR DESCRIPTION
Added `index.js` so that the module can be required and resolved.

[Jira issue](https://issues.apache.org/jira/browse/CB-9712)