### PR TITLE
Absorb cordova-template-reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -179,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,97 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-==============================================================
-This product also include the following software:
-==============================================================
-
---------------------------------------------------------------
-jasmine from GitHub
-
-   https://github.com/pivotal/jasmine
-
-MIT-style license
-
-license available from:
-
-   https://github.com/pivotal/jasmine/blob/master/MIT.LICENSE
-   
------------------------------
-
-Copyright (c) 2008-2011 Pivotal Labs
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
---------------------------------------------------------------
-commonjs tests from the commonjs organization at GitHub
-
-   https://github.com/commonjs/commonjs
-
-MIT-style license
-
-license available from:
-
-   https://github.com/commonjs/commonjs/blob/master/docs/license.html.markdown
-
-contributor list available from:
-
-   https://github.com/commonjs/commonjs/blob/master/docs/contributors.html.markdown
-
------------------------------
-
-Copyright 2009 Kevin Dangoor
-Copyright 2009 Ihab Awad
-Copyright 2009 Ash Berlin
-Copyright 2009 Aristid Breitkreuz
-Copyright 2009 Kevin Dangoor
-Copyright 2009 Daniel Friesen
-Copyright 2009 Wes Garland
-Copyright 2009 Kris Kowal
-Copyright 2009 Dean Landolt
-Copyright 2009 Peter Michaux
-Copyright 2009 George Moschovitis
-Copyright 2009 Michael O'Brien
-Copyright 2009 Tom Robinson
-Copyright 2009 Hannes Wallnoefer
-Copyright 2009 Mike Wilson
-Copyright 2009 Ondrej Zara
-Copyright 2009 Chris Zumbrunn
-Copyright 2009 Kris Zyp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -21,25 +21,47 @@
 
 # Apache Cordova Hello World Application
 
-Simple Hello World application. This is used as the default app template
-when creating new projects.
+A simple Hello World application that serves two purposes:
+- It is used as the default app template when creating new projects
+- It is a reference for building and publishing custom Cordova Templates
 
-## Versions and Tags
+## Structure of your template
+```
+template_package
+├── package.json (for your template package to be published on npm)
+├── index.js
+└── template_src (contains template files)
+    ├── package.json
+    ├── config.xml
+    └── (files and folders that make up the template)
+```
+### Outside of `template_src`
+All files outside of `template_src` are used to define parameters about the template. These files are not copied over at creation, so feel free to add a README or any other files outside  of template_src.
 
-The Hello World's version is directly tied to an Apache Cordova release.
+#### index.js
+`index.js` points to where the template exists. You'll see that index.js usually looks like:
+```javascript
+var path = require('path');
 
-For example, Hello World `2.0.0` is compatible with Apache Cordova `2.0.0`.
+module.exports = {
+    dirname : path.join(__dirname, 'template_src')
+};
+```
 
-To update the snapshot within a platform repo, copy `www/` into the repo's
-template directory, and copy in the relevant files from `res/` as well.
+#### package.json
+This `package.json` holds *information about the template itself* like its name, version etc. All templates should contain the keyword `"cordova:template"` so that the template is searchable on npm. For example:
+```json
+{
+    "name": "cordova-example-template",
+    "version": "1.0.0",
+    "...": "...",
+    "keywords": [
+        "cordova:template"
+    ]
+}
+```
 
-## How to Update
+### Inside of `template_src`
+All files inside of `template_src` compose the template from which a user would desire in order to create their project. Everything in this folder is copied over to the created project.
 
-Update to Apache Cordova x.x.x by:
-
-1. `VERSION`
-    - Update the version
-2. Commit and Tag
-    - `git commit -am "[app] Version x.x.x"`
-    - `git tag x.x.x`
-
+The package.json in `template_src` should be filled with information that describes *the project that would be created from the template*.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,6 @@
 
 var path = require('path');
 
-module.exports = module.exports = {
+module.exports = {
     dirname: path.join(__dirname, 'template_src')
 };

--- a/template_src/package.json
+++ b/template_src/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
   "author": "Apache Cordova Team",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
See https://github.com/apache/cordova-discuss/issues/91

This does not include `template_docs.md` from `cordova-template-reference` since that is only an earlier version of the [template docs](https://cordova.apache.org/docs/en/latest/guide/cli/template.html).