### PR TITLE
chore: move whitelist plugin to package.json

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -26,8 +26,6 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
-    <!-- Whitelist configuration. Refer to https://cordova.apache.org/docs/en/edge/guide_appdev_whitelist_index.md.html -->
-    <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />

--- a/template_src/package.json
+++ b/template_src/package.json
@@ -11,5 +11,8 @@
     "ecosystem:cordova"
   ],
   "author": "Apache Cordova Team",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "cordova-plugin-whitelist": "^1.3.4"
+  }
 }


### PR DESCRIPTION
### Platforms affected

none

### Motivation and Context

Since Cordova 9.x, `cordova plugin add` adds plugins to the `package.json` and no longer added to `config.xml`. 

For consistency, it would be nice if the default whitelist plugin were also in `package.json`. Even if this is it held for the next major.

closes: https://github.com/apache/cordova-app-hello-world/issues/39

### Description

* Move `cordova-plugin-whitelist` to `package.json`.
* Deleted `cordova-plugin-whitelist` from `config.xml`

### Testing

- Not Available

### Checklist

- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
