### PR TITLE
chore: bump version to 5.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-app-hello-world",
-  "version": "4.0.1-dev",
+  "version": "5.0.0-dev",
   "description": "This is the hello world app used by the `cordova create` command.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This marks the beginning of the next major version, to be able to merge the major (IMO) change from #50.

I don't know if we want to merge any existing PRs before that, or if we want to release a minor version. But I guess that's not necessary.
