### PR TITLE
fix: move default plugin to package.json

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -27,7 +27,6 @@
     </author>
     <content src="index.html" />
     <!-- Whitelist configuration. Refer to https://cordova.apache.org/docs/en/edge/guide_appdev_whitelist_index.md.html -->
-    <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />

--- a/template_src/package.json
+++ b/template_src/package.json
@@ -11,5 +11,13 @@
     "ecosystem:cordova"
   ],
   "author": "Apache Cordova Team",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "cordova-plugin-whitelist": "^1.3.4"
+  },
+  "cordova": {
+    "plugins": {
+      "cordova-plugin-whitelist": {}
+    }
+  }
 }


### PR DESCRIPTION
### Platforms affected
All


### Motivation and Context
Current versions of Cordova expect dependencies to be defined in
package.json. This updates the sample app to adhere to that practice.

Fixes #39, Closes #42

### Description
<!-- Describe your changes in detail -->
Move dependency on `cordova-plugin-whitelist` from `config.xml` to `package.json`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Created a new project and added `cordova-browser`. No migration messages anymore:
```
$ cordova platform add browser
Using cordova-fetch for cordova-browser@^6.0.0
Adding browser project...
Creating Cordova project for cordova-browser:
	Path: /tmp/tmp.f0ZSdIZxxL/app/platforms/browser
	Name: HelloCordova
Discovered saved plugin "cordova-plugin-whitelist". Adding it to the project
Installing "cordova-plugin-whitelist" for browser
Adding cordova-plugin-whitelist to package.json

```
