### PR TITLE
[enhancement] XML declaration to default

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file

--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
XML documents begin with an XML declaration that describes some information about themselves. The default and standard declaration: `<?xml version="1.0" encoding="UTF-8"?>`

- Charset UTF-8 in capital letters as standard in XML definition (the default).
- Set in double quotation mark as default.
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Checklist

- [x] I've updated the documentation if necessary
