### PR TITLE
chore: remove whitelist plugin & reference

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -26,7 +26,7 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
-    <!-- Whitelist configuration. Refer to https://cordova.apache.org/docs/en/edge/guide_appdev_whitelist_index.md.html -->
+    <!-- Allow list configuration can be found at: https://cordova.apache.org/docs/en/latest/ -->
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />

--- a/template_src/package.json
+++ b/template_src/package.json
@@ -11,13 +11,5 @@
     "ecosystem:cordova"
   ],
   "author": "Apache Cordova Team",
-  "license": "Apache-2.0",
-  "devDependencies": {
-    "cordova-plugin-whitelist": "^1.3.4"
-  },
-  "cordova": {
-    "plugins": {
-      "cordova-plugin-whitelist": {}
-    }
-  }
+  "license": "Apache-2.0"
 }

--- a/template_src/www/index.html
+++ b/template_src/www/index.html
@@ -21,8 +21,8 @@
     <head>
         <meta charset="utf-8">
         <!--
-        Customize this policy to fit your own app's needs. For more guidance, see:
-            https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
+        Customize this policy to fit your own app's needs. For more guidance, please refer to the docs:
+            https://cordova.apache.org/docs/en/latest/
         Some notes:
             * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
             * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly


### PR DESCRIPTION
### Motivation, Context & Description

* Remove whitelist plugin from template.
* External plugin is being deprecated.

### Testing

- Created project
- Add platform/plugin
