### PR TITLE
chore(ios): remove gap from CSP

### DIFF
--- a/template_src/www/index.html
+++ b/template_src/www/index.html
@@ -24,12 +24,11 @@
         Customize this policy to fit your own app's needs. For more guidance, see:
             https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
         Some notes:
-            * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
             * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
             * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
                 * Enable inline JS: add 'unsafe-inline' to default-src
         -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;">
         <meta name="format-detection" content="telephone=no">
         <meta name="msapplication-tap-highlight" content="no">
         <meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation, Context & Description

Per inline comment:

> gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication

As UIWebView was removed and deprecated, this should no longer be required.

### Testing

- none

### Checklist

- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
