### PR TITLE
cleanup!(config.xml): simplify defaults

### DIFF
--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -17,28 +17,32 @@
  specific language governing permissions and limitations
  under the License.
 -->
-<widget id="io.cordova.hellocordova" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget xmlns="http://www.w3.org/ns/widgets"
+    xmlns:cdv="http://cordova.apache.org/ns/1.0"
+    id="io.cordova.hellocordova"
+    version="1.0.0">
     <name>HelloCordova</name>
-    <description>
-        A sample Apache Cordova application that responds to the deviceready event.
-    </description>
-    <author email="dev@cordova.apache.org" href="http://cordova.io">
+    <description>Sample Apache Cordova App</description>
+    <author email="dev@cordova.apache.org" href="https://cordova.apache.org">
         Apache Cordova Team
     </author>
+
     <content src="index.html" />
-    <!-- Allow list configuration can be found at: https://cordova.apache.org/docs/en/latest/ -->
-    <access origin="*" />
+
+    <!-- To allow connections to other resources, you must explicitly permit them using `access` tags. -->
+    <!-- https://s.apache.org/cdv-network-request-access -->
+    <!-- Example:
+    <access allow="https://cordova.apache.org" />
+    -->
+
+    <!-- To control which URLs the WebView itself can be navigated to, use the `allow-navigation` tags. -->
+    <!-- https://s.apache.org/cdv-allow-navigation -->
+    <!-- Example:
+    <allow-navigation href="https://cordova.apache.org/*" />
+    -->
+
+    <!-- To control which URLs the app is allowed to ask the system to open, use the `allow-intent` tags. -->
+    <!-- https://s.apache.org/cdv-allow-intent -->
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
-    <allow-intent href="tel:*" />
-    <allow-intent href="sms:*" />
-    <allow-intent href="mailto:*" />
-    <allow-intent href="geo:*" />
-    <platform name="android">
-        <allow-intent href="market:*" />
-    </platform>
-    <platform name="ios">
-        <allow-intent href="itms:*" />
-        <allow-intent href="itms-apps:*" />
-    </platform>
 </widget>

--- a/template_src/config.xml
+++ b/template_src/config.xml
@@ -27,6 +27,7 @@
         Apache Cordova Team
     </author>
 
+    <!-- https://s.apache.org/cdv-content-config -->
     <content src="index.html" />
 
     <!-- To allow connections to other resources, you must explicitly permit them using `access` tags. -->


### PR DESCRIPTION
### Platforms affected

all

### Motivation and Context

Not all apps require the pre-define settings that we prodived.

The core template should be as minimalist as possible.

### Description

* Removed all predefined settings except for the basic `allow-intent` of `http` and `https`, so pages can continue to open the system browser.
* Provide a simple instruction for `access`, `allow-navigation` and `allow-intent`.
* Include 1 example for `access` and `allow-navigation`. `allow-intent` was excluded because it contains an actual usage. 
* Added direct link to the `access`, `allow-navigation` and `allow-intent` documentation anchor point.

**Other Changes:**

* Shorten the template `description`
* Updated `author` url
* Formatted XML

### Checklist

- [ ] I've updated the documentation if necessary
  * The website documentation should list our the old defaults, not just in example configs, so users can read how to enable certain features. E.g. tel, geo, sms, etc...
